### PR TITLE
Add support for versions of services

### DIFF
--- a/examples/calculator_service/calculator_service/actions.py
+++ b/examples/calculator_service/calculator_service/actions.py
@@ -21,9 +21,18 @@ class AddAction(Action):
 
 
 class SubtractAction(AddAction):
-
     def run(self, **kwargs):
         self.result = self.number1 - self.number2
+
+
+class BackwardSubtractAction(SubtractAction):
+    def run(self, **kwargs):
+        self.result = self.number2 - self.number1
+
+
+class MultiplyAction(AddAction):
+    def run(self, **kwargs):
+        self.result = self.number1 * self.number2
 
 
 class DivideAction(Action):

--- a/examples/calculator_service/calculator_service/service.py
+++ b/examples/calculator_service/calculator_service/service.py
@@ -13,3 +13,11 @@ class CalculatorService(Service):
             'subtract': actions.SubtractAction,
             'divide': actions.DivideAction,
     }
+
+
+class CalculatorServiceV2(CalculatorService):
+    version = 2
+    action_map = {
+            'multiply': actions.MultiplyAction,
+            'subtract': actions.BackwardSubtractAction,
+    }

--- a/examples/calculator_service/test_calculator.py
+++ b/examples/calculator_service/test_calculator.py
@@ -3,7 +3,7 @@ import servant.client
 client = servant.client.Client('calculator_service', version=1)
 # Uncomment this line and change the connection settings in order to hit an HTTP version of the
 # service
-client.configure('http', host='192.168.88.100', port=8888)
+# client.configure('http', host='192.168.88.100', port=8888)
 
 def _handle_error(response):
     print response.errors, response.field_errors
@@ -40,3 +40,11 @@ def do_divide():
 
 
 do_divide()
+
+
+client = servant.client.Client('calculator_service', version=2)
+response = client.multiply(number1=12, number2=12)
+if response.is_error():
+    print response.errors
+else:
+    print response.result

--- a/servant/client/__init__.py
+++ b/servant/client/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ..transport import get_client_transport_class_by_name
 from ..utils import generate_cid
 
@@ -7,12 +9,16 @@ from .response import Response
 
 class Client(object):
 
-    def __init__(self, service_name, service_version=1, **kwargs):
+    def __init__(self, service_name, version=1, **kwargs):
         self.service_name = service_name
-        self.service_version = service_version
+        self.service_version = version
 
-        if 'version' in kwargs:
-            self.service_version = kwargs['version']
+        # safety check since the kwarg was changed from service_version to version. I believe
+        # all clients were already using 'version'
+        if 'service_version' in kwargs:
+            msg = "The use of service_version is being deprecated. Plese use the version kwarg."
+            warnings.warn(msg, DeprecationWarning)
+            self.service_version = kwargs['service_version']
 
         self.service_meta = kwargs
 

--- a/servant/client/__init__.py
+++ b/servant/client/__init__.py
@@ -10,6 +10,10 @@ class Client(object):
     def __init__(self, service_name, service_version=1, **kwargs):
         self.service_name = service_name
         self.service_version = service_version
+
+        if 'version' in kwargs:
+            self.service_version = kwargs['version']
+
         self.service_meta = kwargs
 
         self.__transport = None
@@ -111,7 +115,7 @@ class InternalClient(object):
         * do_begin_response: causes the service errors to be reset.
                 This can be useful if your actions are independent and you
                 only care about the latest action's errors.
-        
+
         Note: `do_begin_response` only solves the problem of resetting
         the response errors between requests.
         The InternalClient needs more thought for complicated used cases

--- a/servant/transport/local.py
+++ b/servant/transport/local.py
@@ -1,6 +1,7 @@
 import importlib
 
 from .base import BaseTransport
+from ..service import Service
 
 
 class LocalTransport(BaseTransport):
@@ -41,10 +42,8 @@ class LocalTransport(BaseTransport):
                 continue
 
             instance = obj()
-            # uber-safe final check to make sure we have the correct service
-            # class
-            if not 'Service' in {b.__name__ for b in
-                    instance.__class__.__bases__}:
+            # uber-safe final check to make sure we have the correct service class
+            if not isinstance(instance, Service):
                 continue
 
             return instance

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='servant',
     packages=find_packages(exclude=['test', 'examples', 'examples.*']),
-    version = '0.0.9',
+    version = '0.1.0',
     description = 'A library for building services',
     author='Brian Zambrano',
     author_email='brianz@gmail.com',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
 pytest
 pytest-coverage
+tox
 -e .
+-e examples/calculator_service/

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest
+pytest-coverage
 -e .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,8 @@ from servant.client import Client
 from servant.service.actions import Action
 from servant.service.base import Service
 
-# use a singleton client
-__client = None
 
-
-class DoSomethingAction(Action):
+class SayNameAction(Action):
     name = servant.fields.StringField(
             default='Test Service',
             in_response=True,
@@ -23,13 +20,34 @@ class DoSomethingAction(Action):
         if not self.age:
             self.age = random.randint(0, 100)
 
+class SayFullNameAction(Action):
+    first_name = servant.fields.StringField(
+            required=True,
+    )
+    last_name = servant.fields.StringField(
+            required=True,
+    )
+    full_name = servant.fields.StringField(
+            in_response=True,
+    )
+
+    def run(self, **kwargs):
+        self.full_name = '%s %s' % (self.first_name.title(), self.last_name.title())
+
+
 
 class TestService(Service):
     name = 'test_service'
     version = 1
 
     action_map = {
-            'say_name': DoSomethingAction,
+            'say_name': SayNameAction,
+    }
+
+class TestServiceV2(TestService):
+    version = 2
+    action_map = {
+            'say_full_name': SayFullNameAction,
     }
 
 
@@ -43,11 +61,15 @@ def pytest_configure(config):
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def test_client():
-    global __client
-    if __client is None:
-        __client = Client('test_service', version=1)
-        __client.configure_from_service_instance(TestService())
-    return __client
+    client = Client('test_service', version=1)
+    client.configure_from_service_instance(TestService())
+    return client
 
+
+@pytest.fixture(scope='session')
+def test_client_v2():
+    client = Client('test_service', version=2)
+    client.configure_from_service_instance(TestServiceV2())
+    return client

--- a/tests/test_basic_service.py
+++ b/tests/test_basic_service.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 def test_test_client(test_client):
     response = test_client.say_name()
     assert not response.is_error()
@@ -20,3 +19,15 @@ def test_test_client_errors(test_client):
     assert response.is_error()
     assert response.field_errors.age[0].error == "Value 'abc' is not int"
     assert not response.errors
+
+
+def test_client_v2(test_client_v2):
+    response = test_client_v2.say_name()
+    assert not response.is_error()
+    assert response.name == 'Test Service'
+
+
+def test_client_v2_full_name(test_client_v2):
+    response = test_client_v2.say_full_name(first_name='tom', last_name='jones')
+    assert not response.is_error()
+    assert response.full_name == 'Tom Jones'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,61 @@
+import pytest
+
+from servant.client import Client
+
+# the calculator service lives in the examples/ directory and is installed automatically when
+# running tests via tox
+@pytest.fixture
+def clientv1():
+    return Client('calculator_service', version=1)
+
+@pytest.fixture
+def clientv2():
+    return Client('calculator_service', version=2)
+
+
+def test_calculator_v1(clientv1):
+    response = clientv1.subtract(number1=11, number2=2)
+    assert not response.is_error()
+    assert response.result == 9
+
+def test_calculator_v1_no_multiply(clientv1):
+    response = clientv1.multiply(number1=10, number2=20)
+    assert response.is_error()
+    assert response.errors == [u'No action named "multiply" found']
+
+
+def test_calculator_v2_add(clientv2):
+    response = clientv2.add(number1=10, number2=22)
+    assert not response.is_error()
+    assert response.result == 32
+
+def test_calculator_v2_divide(clientv2):
+    response = clientv2.divide(numerator=10, denominator=2)
+    assert not response.is_error()
+    assert response.quotient == 5
+
+def test_calculator_v2_multiply(clientv2):
+    response = clientv2.multiply(number1=10, number2=20)
+    assert not response.is_error()
+    assert response.result == 200
+
+def test_calculator_v2_subtract_has_been_overriden(clientv2):
+    response = clientv2.subtract(number1=11, number2=2)
+    assert not response.is_error()
+    assert response.result == -9
+
+
+def test_client_version():
+    client = Client('foo', version=1)
+    assert client.service_version == 1
+
+def test_client_service_version():
+    # test that service_version raises a deprecation warning
+    pytest.deprecated_call(Client, 'foo', service_version=1)
+
+def test_invalid_version():
+    client = Client('calculator_service', version=3)
+    with pytest.raises(Exception) as execinfo:
+        client.add(number1=10, number2=22)
+
+    assert 'Could not find appropriate Service class' in str(execinfo.value)

--- a/tests/test_service_class.py
+++ b/tests/test_service_class.py
@@ -1,0 +1,91 @@
+import pytest
+
+from servant.service.base import Service
+
+
+class Mixin(object):
+    mixin = True
+
+class ServiceV1(Service):
+    version = 1
+    name = 'test_service'
+    action_map = {
+            'foo': 'foo1',
+            'bar': 'bar1',
+    }
+
+class ServiceV2(ServiceV1):
+    version = 1
+    action_map = {'foo': 'foo2'}
+
+class ServiceV3(Mixin, ServiceV2):
+    version = 1
+    action_map = {
+            'foo': 'foo3',
+            'bar': 'bar3',
+            'baz': 'baz3',
+    }
+
+class ServiceV4(Service):
+    version = 1
+    action_map = {
+            'baz': 'baz4',
+            'some_action': 555,
+    }
+
+class ServiceWithMultipleInheritence(ServiceV3, ServiceV4):
+    version = 555
+
+
+
+def test_version2():
+    v2 = ServiceV2()
+    assert v2.action_map == {
+            'foo': 'foo2',
+            'bar': 'bar1',
+    }
+
+def test_version3():
+    v3 = ServiceV3()
+    assert v3.action_map == {
+            'foo': 'foo3',
+            'bar': 'bar3',
+            'baz': 'baz3',
+    }
+    assert v3.mixin is True
+
+def test_multiple_inheritence():
+    s = ServiceWithMultipleInheritence()
+    assert s.version == 555
+    assert s.action_map == {
+            'foo': 'foo3',
+            'bar': 'bar3',
+            'baz': 'baz4',
+            'some_action': 555,
+    }
+
+def test_missing_name():
+    class NoName(Service):
+        version = 1
+        action_map = {}
+
+    with pytest.raises(Exception):
+        NoName()
+
+
+def test_missing_version():
+    class NoVersion(Service):
+        name = 'service'
+        action_map = {}
+
+    with pytest.raises(Exception):
+        NoName()
+
+
+def test_missing_action_map():
+    class NoActionMap(Service):
+        name = 'service'
+        version = 1
+
+    s = NoActionMap()
+    assert s.action_map == {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+# envlist = py27, py33
+# commands = py.test tests/
+
+[tox]
+envlist = py27, py34, pypy
+
+[testenv]
+basepython = 
+    py27: python2.7
+    py34: python2.7
+    pypy: pypy
+commands = py.test tests/
+deps =
+    pytest
+    pytest-coverage
+    examples/calculator_service/


### PR DESCRIPTION
This allows for easy subclassing of services which will allow authors to
use existing endpoints and override in a targeted fashion.  At the same
time it's trivial to add a new endpoint.  Currently there isn't a way to
remove an endpoint.

Requesting a version of a service which doesn't exists raises an error.
Clients may request a different version by simply changing the `version` argument.